### PR TITLE
docs: deprecation notice — migrating to Sequence assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Polygon Assets
 
+> [!WARNING]
+> **This service is deprecated and being wound down — do not add new consumers.**
+>
+> Per the 2026-07-23 Apps Team product review, these token/chain/brand icon
+> assets overlap Sequence's assets metadata and are being retired. Retiring
+> this repository is gated on two migrations that must land first: (1) moving
+> validator/logo images into the staking API backend, ending the manual
+> PR-based asset process this repo currently relies on, and (2) switching
+> remaining consumers to Sequence assets.
+>
+> No new assets or consumers should be added here. This repository will be
+> archived once both migrations are complete.
+
 This repository contains the brand and token assets used on Polygon products.
 
 # Deploy to Staging or Prod environments


### PR DESCRIPTION
Per the 2026-07-23 Apps Team product review, these token/chain/brand icon assets overlap Sequence's assets metadata and are being retired. Retiring this repo is gated on two migrations landing first: (1) moving validator/logo images into the staking API backend, ending the manual PR-based asset process, and (2) switching remaining consumers to Sequence assets.

This PR adds a deprecation banner to the README to discourage new asset PRs in the meantime; no functional change.
